### PR TITLE
Fix xmldom on Debian

### DIFF
--- a/scripts/symbols.js
+++ b/scripts/symbols.js
@@ -1,6 +1,6 @@
 const fs = require("fs");
 const path = require("path");
-const { DOMParser, XMLSerializer, DOMImplementation } = require("xmldom");
+const { DOMParser, XMLSerializer, DOMImplementation } = require("@xmldom/xmldom");
 
 const getSvg = (symbol) => {
   const bounds = getBounds(symbol);


### PR DESCRIPTION
On Debian, the xmldom module was not found by the script although it was installed in the system. A small change to the require call, fixes this problem.

I'm not very used to Nodejs, but this looks to be the correct way to fix it.